### PR TITLE
Use correct import in Postgres example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const uzer = new SqliteUzer({
 ```ts
 import { PostgresUzer } from 'uzer'
 
-const uzer = Uzer({
+const uzer = PostgresUzer({
   tableName: "mytable",
   db: {
     host: 'localhost',


### PR DESCRIPTION
Hey :wave: 

Noticed you were importing `Uzer` in the Postgres documentation but you've named the import `PostgresUzer` :+1: